### PR TITLE
feat: current date will now be highlighted on hover

### DIFF
--- a/modules/home/waybar/settings.nix
+++ b/modules/home/waybar/settings.nix
@@ -24,6 +24,9 @@
         "network"
     ];
     clock= {
+        calendar = {
+          format = { today = "<span color='#ff6699'><b><u>{}</u></b></span>"; };
+        };
         format = " {:%H:%M}";
         tooltip= "true";
         tooltip-format= "<big>{:%Y %B}</big>\n<tt><small>{calendar}</small></tt>";


### PR DESCRIPTION
When user hovers on the date module, the current date will now be highlighted. The highlight color can be changed.
![pull](https://github.com/Frost-Phoenix/nixos-config/assets/151028199/de100a88-bed6-4c14-8a05-d3da4c712aae)
