### PR TITLE
core: enable auto-discovery of network printers

### DIFF
--- a/modules/core/default.nix
+++ b/modules/core/default.nix
@@ -8,6 +8,7 @@
     ./network.nix
     ./nh.nix
     ./pipewire.nix
+    ./printing.nix
     ./program.nix
     ./security.nix
     ./services.nix

--- a/modules/core/printing.nix
+++ b/modules/core/printing.nix
@@ -1,0 +1,19 @@
+{ pkgs, ... }:
+{
+  services = {
+    avahi = {
+      enable = true;
+      nssmdns4 = true;
+      openFirewall = true;
+    };
+
+    printing = {
+      enable = true;
+      drivers = with pkgs; [
+        cups-filters
+        cups-browsed
+      ];
+    };
+  };
+}
+


### PR DESCRIPTION
This PR enables automatic discovery of network printers by configuring CUPS and Avahi daemon.

With these changes, printers supporting the IPP Everywhere protocol should "just work" without any additional manual configuration. This significantly improves the out-of-the-box experience for most modern network printers.

Implementation follows the [NixOS Wiki article on Printing](https://wiki.nixos.org/wiki/Printing).