### PR TITLE
Add OCR support to Hyprland window manager

### DIFF
--- a/modules/home/hyprland/binds.nix
+++ b/modules/home/hyprland/binds.nix
@@ -44,6 +44,9 @@
       "$mod, Print, exec, screenshot --save"
       "$mod SHIFT, Print, exec, screenshot --swappy"
 
+      # OCR
+      "$mod CTRL, O, exec, ocr"
+
       # switch focus
       "$mod, left,  movefocus, l"
       "$mod, right, movefocus, r"

--- a/modules/home/hyprland/hyprland.nix
+++ b/modules/home/hyprland/hyprland.nix
@@ -12,6 +12,7 @@
     glib
     wayland
     direnv
+    tesseract
   ];
   systemd.user.targets.hyprland-session.Unit.Wants = [
     "xdg-desktop-autostart.target"

--- a/scripts/scripts/ocr.sh
+++ b/scripts/scripts/ocr.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Create temporary file for screenshot
+temp_image=$(mktemp /tmp/ocr-screenshot-XXXXXX.png)
+
+# Capture screen area with grimblast
+grimblast --freeze save area "$temp_image"
+
+# Perform OCR and copy to clipboard
+tesseract "$temp_image" stdout 2>/dev/null | wl-copy
+
+# Clean up temporary file
+rm -f "$temp_image"


### PR DESCRIPTION
- Add tesseract OCR engine as dependency
- Add keybinding (Super+Ctrl+O) to trigger OCR
- Create ocr.sh script for screen area text extraction
- OCR script captures selected area, extracts text with tesseract, and copies to clipboard