### PR TITLE
Add Blanket ambient sounds with instant Hyprland toggle

### DIFF
--- a/modules/home/hyprland/binds.nix
+++ b/modules/home/hyprland/binds.nix
@@ -36,6 +36,7 @@
       "$mod, N, exec, swaync-client -t -sw"
       "CTRL SHIFT, Escape, exec, hyprctl dispatch exec '[workspace 9] missioncenter'"
       "$mod, equal, exec, woomer"
+      "$mod, A, exec, toggle-blanket"
       # "$mod SHIFT, W, exec, vm-start"
 
       "$mod, XF86Display, exec, toggle-display"

--- a/modules/home/hyprland/exec-once.nix
+++ b/modules/home/hyprland/exec-once.nix
@@ -23,5 +23,6 @@
     "ghostty --gtk-single-instance=true --quit-after-last-window-closed=false --initial-window=false"
     "[workspace 1 silent] zen-beta"
     "[workspace 2 silent] ghostty"
+    "blanket --hidden &"
   ];
 }

--- a/modules/home/hyprland/hyprland.nix
+++ b/modules/home/hyprland/hyprland.nix
@@ -13,6 +13,7 @@
     wayland
     direnv
     tesseract
+    blanket
   ];
   systemd.user.targets.hyprland-session.Unit.Wants = [
     "xdg-desktop-autostart.target"

--- a/modules/home/hyprland/windowrules.nix
+++ b/modules/home/hyprland/windowrules.nix
@@ -13,6 +13,8 @@
 
       "match:class ^(rofi)$, pin on"
       "match:class ^(waypaper)$, pin on"
+      "match:class ^(com.rafaelmardojai.Blanket)$, float on"
+      "match:class ^(com.rafaelmardojai.Blanket)$, size 600 700"
 
       "match:class ^(Aseprite)$, tile on"
 

--- a/modules/home/hyprland/windowrules.nix
+++ b/modules/home/hyprland/windowrules.nix
@@ -15,6 +15,7 @@
       "match:class ^(waypaper)$, pin on"
       "match:class ^(com.rafaelmardojai.Blanket)$, float on"
       "match:class ^(com.rafaelmardojai.Blanket)$, size 600 700"
+      "match:class ^(com.rafaelmardojai.Blanket)$, workspace special:blanket silent"
 
       "match:class ^(Aseprite)$, tile on"
 

--- a/scripts/scripts/toggle-blanket.sh
+++ b/scripts/scripts/toggle-blanket.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+if hyprctl clients -j | jq -e ".[] | select(.class == \"com.rafaelmardojai.Blanket\")" > /dev/null; then
+    hyprctl dispatch togglespecialworkspace blanket
+else
+    hyprctl dispatch exec "[workspace special:blanket] blanket"
+fi

--- a/scripts/scripts/toggle-blanket.sh
+++ b/scripts/scripts/toggle-blanket.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
-if hyprctl clients -j | jq -e ".[] | select(.class == \"com.rafaelmardojai.Blanket\")" > /dev/null; then
+class="com.rafaelmardojai.Blanket"
+
+if hyprctl clients -j | jq -e ".[] | select(.class == \"$class\")" > /dev/null; then
+    # Window already exists (pinned to special:blanket by windowrule) -> toggle visibility.
     hyprctl dispatch togglespecialworkspace blanket
 else
-    hyprctl dispatch exec "[workspace special:blanket] blanket"
+    # No window yet (e.g. started with `blanket --hidden`). Surface the single
+    # instance, wait for the window to map, then reveal the special workspace.
+    hyprctl dispatch exec blanket
+    for _ in $(seq 1 30); do
+        if hyprctl clients -j | jq -e ".[] | select(.class == \"$class\")" > /dev/null; then
+            break
+        fi
+        sleep 0.1
+    done
+    hyprctl dispatch togglespecialworkspace blanket
 fi


### PR DESCRIPTION
Add [Blanket](https://github.com/rafaelmardojai/blanket) with a toggle script that preloads it hidden at login and allows instant show/hide via `$mod + A`. Uses a special workspace to keep blanket invisible when dismissed.

- New `toggle-blanket.sh` script
- `$mod, A` keybind
- Auto-start hidden at login
- Window rules: floating, 600x700